### PR TITLE
Initialize drawings array

### DIFF
--- a/client/src/components/Firebase/Firebase.js
+++ b/client/src/components/Firebase/Firebase.js
@@ -90,6 +90,7 @@ class Firebase {
       gameName: gameName,
       players: [],
       creationDate: this.fieldValue.serverTimestamp(),
+      drawings: [],
       currentPlayerIndex: 0,
       hasStarted: false,
       timeLimit: timeLimit,


### PR DESCRIPTION
Fix bug where drawings array is uninitialized in new games, causing an index-out-of-bounds error.